### PR TITLE
Tensorflow 0.9 compatibility 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ python:
 install:
   # install TensorFlow from https://storage.googleapis.com/tensorflow/
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0-cp27-none-linux_x86_64.whl;
+      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp27-none-linux_x86_64.whl;
     elif [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0-cp34-cp34m-linux_x86_64.whl;
+      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp34-cp34m-linux_x86_64.whl;
     fi
 
 # command to run tests

--- a/model.py
+++ b/model.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
-from tensorflow.models.rnn import rnn_cell
-from tensorflow.models.rnn import seq2seq
+from tensorflow.python.ops import rnn_cell
+from tensorflow.python.ops import seq2seq
 
 import numpy as np
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import unittest
 from utils import TextLoader
 import numpy as np
+from collections import Counter
 
 class TestUtilsMethods(unittest.TestCase):
     def setUp(self):
@@ -17,17 +18,17 @@ class TestUtilsMethods(unittest.TestCase):
         print (vocab, vocab_inv)
 
         # Must include I, love, and cat
-        self.assertItemsEqual(vocab, ["I", "love", "cat"])
+        self.assertEqual(Counter(list(vocab)), Counter(list(["I", "love", "cat"])))
         self.assertDictEqual(vocab, {'I': 0, 'love': 2, 'cat': 1})
 
-        self.assertItemsEqual(vocab_inv, ["I", "love", "cat"])
+        self.assertEqual(Counter(list(vocab_inv)), Counter(list(["I", "love", "cat"])))
 
     def test_batch_vocab(self):
         print (np.array(self.data_loader.x_batches).shape)
-        self.assertItemsEqual(self.data_loader.x_batches[0][0][1:],
-                              self.data_loader.y_batches[0][0][:-1])
-        self.assertItemsEqual(self.data_loader.x_batches[0][1][1:],
-                              self.data_loader.y_batches[0][1][:-1])
+        self.assertEqual(Counter(list(self.data_loader.x_batches[0][0][1:])),
+                              Counter(list(self.data_loader.y_batches[0][0][:-1])))
+        self.assertEqual(Counter(list(self.data_loader.x_batches[0][1][1:])),
+                              Counter(list(self.data_loader.y_batches[0][1][:-1])))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Refactored to work with TF 0.9 and retrieve TF 0.9 in the .travis.yml 
Haven't looked at why Python 3.4 build is failing on Travis yet.