### PR TITLE
Beam search fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ python sample.py --pick 2 --width 4
 
 # Sample output
 
-## Word-RNN
+### Word-RNN
 ```
 LEONTES:
 Why, my Irish time?
@@ -54,52 +54,7 @@ That He being and
 full of toad, they knew me to joy.
 ```
 
-## Word-RNN (with beam search)
-```
-KING RICHARD III:
-you, by thou and and be not made at London with my legs.
-
-ROMEO:
-This is the quarrel; for this fellow: ho?
-
-RATCLIFF:
-I pray thee, moralize them.
-
-FERDINAND:
-This is fairy gold, boy, or 'twill do more than a man that calls upon me?
-reflect I not with the basilisk: I have Forbidden bandying in chance,
-
-GREGORY:
-and fret, that I have heard the princess As that she hath been deposed;
-Or late: farewell; my lord. Light to my boon.
-
-LADY CAPULET:
-I will not speak!
-
-KING RICHARD II:
-Marshal, Lartius, thou art,
-Commit'st my abilities are no more doublets thanbacks, thou takest,
-Within the morning, and my advancement?
-I must not be conducted.
-
-DUKE VINCENTIO:
-Repent you the time to visit, I am not strangely in my mouth,
-those that was germane to him, as thou talk'st of contrary.
-
-KING RICHARD II:
-Marshal, Lartius, thou fortunate!
-
-MONTAGUE:
-Comfort, my lord; and say you shall be stoned;
-but my heart shall have a man as stead me thy appointment,
-give me thy brother exercise;
-
-BUCKINGHAM:
-I pray you, mark your penitence, if it be violent, As when I would not disdain.
-```
-
-## Char-RNN
-
+### Char-RNN
 ```
 ESCALUS:
 What is our honours, such a Richard story
@@ -120,6 +75,66 @@ And six nor's mighty wind, I fairs, if?
 Messenger:
 My lank, nobles arms;
 ```
+
+## Beam search
+
+Beam search differs from the other `--pick` options in that it does not greedily
+pick single words; rather, it expands the most promising nodes and keeps a
+running score for each beam.
+
+### Word-RNN (with beam search)
+```
+# python sample.py --prime "KING RICHARD III:" -n 100 --pick 2 --width 4
+
+KING RICHARD III:
+you, and and and and have been to be hanged, I am not to be touched?
+
+Provost:
+A Bohemian born, for tying his own train,
+Forthwith by all that converses more with a crow-keeper;
+I have drunk, Broach'd with the acorn cradled. Follow.
+
+FERDINAND:
+Who would not be conducted.
+
+BISHOP OF ELY:
+If you have been a-bed an acre of barren ground, hath holy;
+I warrant, my lord restored of noon.
+
+ISABELLA:
+'Save my master and his shortness whisper me to the pedlar;
+Money's a medler.
+That I will pamper it to complain.
+
+VOLUMNIA:
+Indeed, I am
+```
+
+### Word-RNN (without beam search)
+```
+# python sample.py --prime "KING RICHARD III:" -n 100
+
+KING RICHARD III:
+marry, so and unto the wind have yours;
+And thou Juliet, sir?
+
+JULIET:
+Well, wherefore speak your disposition cousin;
+May thee flatter.
+My hand will answer him;
+e not to your Mariana Below these those and take this life,
+That stir not light of reason.
+The time Lucentio keeps a root from you.
+Cursed be his potency,
+It was my neighbour till the birth and I drank stay.
+
+MENENIUS:
+Here's the matter,
+I know take this sour place,
+they know allegiance Had made you guilty.
+You do her bear comfort him between him or our noble bosom he did Bolingbroke's
+```
+
 # Projects
 If you have any project using this word-rnn, please let us know. I'll list up your project here.
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,16 @@ To train with default parameters on the tinyshakespeare corpus, run:
 python train.py
 ```
 
-To sample from a trained model"
+To sample from a trained model
 ```bash
 python sample.py
+```
+
+To pick using beam search, use the `--pick` parameter. Beam search can be
+further customized using the `--width` parameter, which sets the number of beams
+to search with. For example:
+```bash
+python sample.py --pick 2 --width 4
 ```
 
 # Sample output
@@ -47,6 +54,50 @@ That He being and
 full of toad, they knew me to joy.
 ```
 
+## Word-RNN (with beam search)
+```
+KING RICHARD III:
+you, by thou and and be not made at London with my legs.
+
+ROMEO:
+This is the quarrel; for this fellow: ho?
+
+RATCLIFF:
+I pray thee, moralize them.
+
+FERDINAND:
+This is fairy gold, boy, or 'twill do more than a man that calls upon me?
+reflect I not with the basilisk: I have Forbidden bandying in chance,
+
+GREGORY:
+and fret, that I have heard the princess As that she hath been deposed;
+Or late: farewell; my lord. Light to my boon.
+
+LADY CAPULET:
+I will not speak!
+
+KING RICHARD II:
+Marshal, Lartius, thou art,
+Commit'st my abilities are no more doublets thanbacks, thou takest,
+Within the morning, and my advancement?
+I must not be conducted.
+
+DUKE VINCENTIO:
+Repent you the time to visit, I am not strangely in my mouth,
+those that was germane to him, as thou talk'st of contrary.
+
+KING RICHARD II:
+Marshal, Lartius, thou fortunate!
+
+MONTAGUE:
+Comfort, my lord; and say you shall be stoned;
+but my heart shall have a man as stead me thy appointment,
+give me thy brother exercise;
+
+BUCKINGHAM:
+I pray you, mark your penitence, if it be violent, As when I would not disdain.
+```
+
 ## Char-RNN
 
 ```
@@ -73,7 +124,7 @@ My lank, nobles arms;
 If you have any project using this word-rnn, please let us know. I'll list up your project here.
 
 - http://bot.wpoem.com/ (Simple poem generator in Korean)
- 
+
 
 # Contribution
 Your comments (issues) and PRs are always welcome.

--- a/beam.py
+++ b/beam.py
@@ -3,27 +3,68 @@ import numpy as np
 
 
 class BeamSearch():
-    def __init__(self, probs):
-        self.probs = probs
+    def __init__(self, predict, initial_state, prime_labels):
+        """Initializes the beam search.
 
-    def beamsearch(self, oov, empty, eos, k=1, maxsample=4000, use_unk=False):
-        """return k samples (beams) and their NLL scores, each sample is a sequence of labels,
-        all samples starts with an `empty` label and end with `eos` or truncated to length of `maxsample`.
-        You need to supply `predict` which returns the label probability of each sample.
-        `use_unk` allow usage of `oov` (out-of-vocabulary) label in samples
+        Args:
+            predict:
+                A function that takes a `sample` and a `state`. It then performs
+                the computation on the last word in `sample`.
+            initial_state:
+                The initial state of the RNN.
+            prime_labels:
+                A list of labels corresponding to the priming text.
         """
+
+        self.predict = predict
+        self.initial_state = initial_state
+        self.prime_labels = prime_labels
+
+    def predict_samples(self, samples, states):
+        probs = []
+        next_states = []
+        for i in range(len(samples)):
+            prob, next_state = self.predict(samples[i], states[i])
+            probs.append(prob.squeeze())
+            next_states.append(next_state)
+        return np.array(probs), next_states
+
+    def search(self, oov, eos, k=1, maxsample=4000, use_unk=False):
+        """Return k samples (beams) and their NLL scores.
+
+        Each sample is a sequence of labels, either ending with `eos` or
+        truncated to length of `maxsample`. `use_unk` allow usage of `oov`
+        (out-of-vocabulary) label in samples
+        """
+
+        # A list of probabilities of our samples.
+        probs = []
+
+        prime_sample = []
+        prime_score = 0
+        prime_state = self.initial_state
+        # Initialize the live sample with the prime.
+        for i, label in enumerate(self.prime_labels):
+            prime_sample.append(label)
+            if i > 0:
+                prime_score = prime_score - np.log(probs[0, label])
+            probs, prime_state = self.predict(prime_sample, prime_state)
 
         dead_k = 0  # samples that reached eos
         dead_samples = []
         dead_scores = []
+        dead_states = []
+
         live_k = 1  # samples that did not yet reached eos
-        live_samples = [[empty]]
-        live_scores = [0]
+        live_samples = [prime_sample]
+        live_scores = [prime_score]
+        live_states = [prime_state]
 
         while live_k and dead_k < k:
+            probs, live_states = self.predict_samples(live_samples, live_states)
 
             # total score for every sample is sum of -log of word prb
-            cand_scores = np.array(live_scores)[:, None] - np.log(self.probs)
+            cand_scores = np.array(live_scores)[:, None] - np.log(probs)
             if not use_unk and oov is not None:
                 cand_scores[:, oov] = 1e20
             cand_flat = cand_scores.flatten()
@@ -33,8 +74,9 @@ class BeamSearch():
             live_scores = cand_flat[ranks_flat]
 
             # append the new words to their appropriate live sample
-            voc_size = self.probs.shape[1]
+            voc_size = probs.shape[1]
             live_samples = [live_samples[r // voc_size] + [r % voc_size] for r in ranks_flat]
+            live_states = [live_states[r // voc_size] for r in ranks_flat]
 
             # live samples that should be dead are...
             zombie = [s[-1] == eos or len(s) >= maxsample for s in live_samples]
@@ -42,10 +84,12 @@ class BeamSearch():
             # add zombies to the dead
             dead_samples += [s for s, z in zip(live_samples, zombie) if z]  # remove first label == empty
             dead_scores += [s for s, z in zip(live_scores, zombie) if z]
+            dead_states += [s for s, z in zip(live_states, zombie) if z]
             dead_k = len(dead_samples)
             # remove zombies from the living
             live_samples = [s for s, z in zip(live_samples, zombie) if not z]
             live_scores = [s for s, z in zip(live_scores, zombie) if not z]
+            live_states = [s for s, z in zip(live_states, zombie) if not z]
             live_k = len(live_samples)
 
         return dead_samples + live_samples, dead_scores + live_scores

--- a/model.py
+++ b/model.py
@@ -80,7 +80,7 @@ class Model():
         optimizer = tf.train.AdamOptimizer(self.lr)
         self.train_op = optimizer.apply_gradients(zip(grads, tvars))
 
-    def sample(self, sess, words, vocab, num=200, prime='first all', sampling_type=1, pick=0):
+    def sample(self, sess, words, vocab, num=200, prime='first all', sampling_type=1, pick=0, width=4):
         def weighted_pick(weights):
             t = np.cumsum(weights)
             s = np.sum(weights)
@@ -93,13 +93,13 @@ class Model():
             """
 
             x = np.zeros((1, 1))
-            x[0, 0] = vocab.get(sample[-1], 0)
+            x[0, 0] = sample[-1]
             feed = {self.input_data: x, self.initial_state: state}
             [probs, final_state] = sess.run([self.probs, self.final_state],
                                             feed)
             return probs, final_state
 
-        def beam_search_pick(prime, width=2):
+        def beam_search_pick(prime, width):
             """Returns the beam search pick."""
             if not len(prime) or prime == ' ':
                 prime = random.choice(list(vocab.keys()))
@@ -146,7 +146,7 @@ class Model():
                 ret += ' ' + pred
                 word = pred
         elif pick == 2:
-            pred = beam_search_pick(prime)
+            pred = beam_search_pick(prime, width)
             for i, label in enumerate(pred):
                 ret += ' ' + words[label] if i > 0 else words[label]
         return ret

--- a/sample.py
+++ b/sample.py
@@ -22,6 +22,8 @@ def main():
                        help='1 = weighted pick, 2 = beam search pick')
     parser.add_argument('--sample', type=int, default=1,
                        help='0 to use max at each timestep, 1 to sample at each timestep, 2 to sample on spaces')
+    parser.add_argument('--width', type=int, default=4,
+                       help='width of the beam search')
 
     args = parser.parse_args()
     sample(args)
@@ -38,7 +40,7 @@ def sample(args):
         ckpt = tf.train.get_checkpoint_state(args.save_dir)
         if ckpt and ckpt.model_checkpoint_path:
             saver.restore(sess, ckpt.model_checkpoint_path)
-            print(model.sample(sess, words, vocab, args.n, args.prime, args.sample, args.pick))
+            print(model.sample(sess, words, vocab, args.n, args.prime, args.sample, args.pick, args.width))
 
 if __name__ == '__main__':
     main()

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -1,0 +1,43 @@
+import unittest
+import numpy as np
+
+from beam import BeamSearch
+
+
+def naive_predict(sample, state):
+    """Fake predict function.
+
+    For our model, let's assume a vocabulary of size 5. Furthermore, let's say
+    that the `state` is exactly the probability that each vocabulary occurs,
+    and these probabilities never change.
+    """
+
+    return np.array(state)[None, :], state
+
+
+class TestBeamMethods(unittest.TestCase):
+    def setUp(self):
+        self.prime_labels = [0, 1]
+        self.initial_state = [0.1, 0.2, 0.3, 0.4, 0.5]
+
+    def test_single_beam(self):
+        bs = BeamSearch(naive_predict, self.initial_state, self.prime_labels)
+        samples, scores = bs.search(None, None, k=1, maxsample=5)
+        self.assertEqual(samples, [[0, 1, 4, 4, 4]])
+
+    def test_multiple_beams(self):
+        bs = BeamSearch(naive_predict, self.initial_state, self.prime_labels)
+        samples, scores = bs.search(None, None, k=4, maxsample=5)
+
+        self.assertIn([0, 1, 4, 4, 4], samples)
+
+        # All permutations of this form must be in the results.
+        self.assertIn([0, 1, 4, 4, 3], samples)
+        self.assertIn([0, 1, 4, 3, 4], samples)
+        self.assertIn([0, 1, 3, 4, 4], samples)
+
+        # Make sure that the best beam has the lowest score.
+        self.assertEqual(samples[np.argmin(scores)], [0, 1, 4, 4, 4])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes beam search through a number of changes:

1. **Beam search as a pick option is no longer grouped with the other sampling methods.**
This was problematic for two reasons. First, beam search does not return a single word pick - it looks for the best beam of up to `num` words. Second, adding the prime text outside of the `beamsearch()` method would mean that the prime text has no impact on the beam search scores. As such, I've separated the different pick options.
2. **We now pass a `predict` function to the `BeamSearch` class, as well as the initial state and the prime text.**
The `predict()` function allows us to perform a single computation on the RNN to figure out next-step probabilities and state. In the context of `beamsearch()`, we use the `predict()` function to progress each beam. We treat the state variable as more or less opaque, using it only with the `predict()` function.