### PR TITLE
Add an --input_encoding argument to train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -14,6 +14,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--data_dir', type=str, default='data/tinyshakespeare',
                        help='data directory containing input.txt')
+    parser.add_argument('--input_encoding', type=str, default=None,
+                       help='character encoding of input.txt, from https://docs.python.org/3/library/codecs.html#standard-encodings')
     parser.add_argument('--log_dir', type=str, default='logs',
                        help='directory containing tensorboard logs')
     parser.add_argument('--save_dir', type=str, default='save',
@@ -39,7 +41,7 @@ def main():
     parser.add_argument('--decay_rate', type=float, default=0.97,
                        help='decay rate for rmsprop')
     parser.add_argument('--gpu_mem', type=float, default=0.666,
-                       help='% of gpu memory to be allocated to this process. Default is 66.6%')
+                       help='%% of gpu memory to be allocated to this process. Default is 66.6%%')
     parser.add_argument('--init_from', type=str, default=None,
                        help="""continue training from saved model at this path. Path must contain files saved by previous training process:
                             'config.pkl'        : configuration;
@@ -52,7 +54,7 @@ def main():
     train(args)
 
 def train(args):
-    data_loader = TextLoader(args.data_dir, args.batch_size, args.seq_length)
+    data_loader = TextLoader(args.data_dir, args.batch_size, args.seq_length, args.input_encoding)
     args.vocab_size = data_loader.vocab_size
 
     # check compatibility if training is continued from previously saved model

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import codecs
 import collections
 from six.moves import cPickle
 import numpy as np
@@ -7,7 +8,7 @@ import re
 import itertools
 
 class TextLoader():
-    def __init__(self, data_dir, batch_size, seq_length):
+    def __init__(self, data_dir, batch_size, seq_length, encoding=None):
         self.data_dir = data_dir
         self.batch_size = batch_size
         self.seq_length = seq_length
@@ -19,7 +20,7 @@ class TextLoader():
         # Let's not read voca and data from file. We many change them.
         if True or not (os.path.exists(vocab_file) and os.path.exists(tensor_file)):
             print("reading text file")
-            self.preprocess(input_file, vocab_file, tensor_file)
+            self.preprocess(input_file, vocab_file, tensor_file, encoding)
         else:
             print("loading preprocessed files")
             self.load_preprocessed(vocab_file, tensor_file)
@@ -60,8 +61,8 @@ class TextLoader():
         vocabulary = {x: i for i, x in enumerate(vocabulary_inv)}
         return [vocabulary, vocabulary_inv]
 
-    def preprocess(self, input_file, vocab_file, tensor_file):
-        with open(input_file, "r") as f:
+    def preprocess(self, input_file, vocab_file, tensor_file, encoding):
+        with codecs.open(input_file, "r", encoding=encoding) as f:
             data = f.read()
 
         # Optional text cleaning or make them lower case, etc.


### PR DESCRIPTION
I was trying to use these scripts with a dataset I downloaded that was in UTF-8. Python 3 uses the system character encoding by default, which on an en-US Windows is CP1252, so it failed. This patch adds an `--input_encoding` argument to train.py so I could simply run `train.py --input_encoding=utf8`.

I also fixed the help text for `--gpu_mem`, which had bare percent signs which broke things when running `train.py --help`.

Thanks for publishing this repository, it's really helpful!